### PR TITLE
问题上报

### DIFF
--- a/synch/writer/merge_tree.py
+++ b/synch/writer/merge_tree.py
@@ -21,7 +21,12 @@ class ClickHouseMergeTree(ClickHouse):
             for pk_value in pk_list:
                 item = []
                 for index, pk_item in enumerate(pk):
-                    item.append(f"{pk_item}={pk_value[index]}")
+                    # There will be problems if the primary key has multiple data types, not just numeric types
+                    v = pk_value[index]
+                    if isinstance(v, (int, float)):
+                        item.append(f"{pk_item}={pk_value[index]}")
+                    else:
+                        item.append(f"{pk_item}='{pk_value[index]}'")
                 pks_list.append("(" + " and ".join(item) + ")")
             sql += " or ".join(pks_list)
         else:

--- a/synch/writer/merge_tree.py
+++ b/synch/writer/merge_tree.py
@@ -34,14 +34,14 @@ class ClickHouseMergeTree(ClickHouse):
         return sql
 
     def get_table_create_sql(
-        self,
-        reader: Reader,
-        schema: str,
-        table: str,
-        pk,
-        partition_by: str = None,
-        engine_settings: str = None,
-        **kwargs,
+            self,
+            reader: Reader,
+            schema: str,
+            table: str,
+            pk,
+            partition_by: str = None,
+            engine_settings: str = None,
+            **kwargs,
     ):
         partition_by_str = ""
         engine_settings_str = ""
@@ -56,14 +56,14 @@ class ClickHouseMergeTree(ClickHouse):
         return f"insert into {schema}.{table} {reader.get_source_select_sql(schema, table, )}"
 
     def handle_event(
-        self,
-        tables_dict: Dict,
-        pk,
-        schema: str,
-        table: str,
-        action: str,
-        tmp_event_list: Dict,
-        event: Dict,
+            self,
+            tables_dict: Dict,
+            pk,
+            schema: str,
+            table: str,
+            action: str,
+            tmp_event_list: Dict,
+            event: Dict,
     ):
         values = self.pre_handle_values(tables_dict.get(table).get("skip_decimal"), event["values"])
         event["values"] = values
@@ -73,7 +73,9 @@ class ClickHouseMergeTree(ClickHouse):
             return tmp_event_list
         else:
             if isinstance(pk, tuple):
-                pk_value = {values[pk[0]], values[pk[1]]}
+                # if use {} ,then TypeError: unhashable type: 'set'
+                # so use ()
+                pk_value = (values[pk[0]], values[pk[1]])
             else:
                 pk_value = values[pk]
             tmp_event_list[table][action][pk_value] = event


### PR DESCRIPTION
作者好，
    这两个问题是我这里出现的，做了修复。
    两个问题都是在 merge_tree这个文件里面 
    第一个是 79行 “tmp_event_list[table][action][pk_value] = event”  当 pk_value为 {}时 会有 不可hash的报错 ，改成了 ()
    第二个是 24行 “item.append(f"{pk_item}={pk_value[index]}")”  当 主键有字符类型时 ，在clickhouse里面会有转换失败的报错。
例如  test 表主键 name 是 字符型 ，生成的 delete 的sql是  alter table test delete where name=姓名; 
所以判断了下字符类型就添加了''