### PR TITLE
feat: merge_tree delete_events pk support different type

### DIFF
--- a/synch/writer/merge_tree.py
+++ b/synch/writer/merge_tree.py
@@ -15,6 +15,7 @@ class ClickHouseMergeTree(ClickHouse):
         """
         delete record by pk
         """
+        sql_params = None
         if isinstance(pk, tuple):
             sql = f"alter table {schema}.{table} delete where "
             pks_list = []
@@ -29,23 +30,20 @@ class ClickHouseMergeTree(ClickHouse):
                 pks_list.append("(" + " and ".join(item) + ")")
             sql += " or ".join(pks_list)
         else:
-            if len(pk_list) > 1:
-                pks = ",".join(str(pk) for pk in pk_list)
-            else:
-                pks = pk_list[0]
-            sql = f"alter table {schema}.{table} delete where {pk} in ({pks})"
-        self.execute(sql)
+            sql_params = {pk: tuple(pk_list)}
+            sql = f"alter table {schema}.{table} delete where {pk} in %({pk})s"
+        self.execute(sql, sql_params)
         return sql
 
     def get_table_create_sql(
-        self,
-        reader: Reader,
-        schema: str,
-        table: str,
-        pk,
-        partition_by: str = None,
-        engine_settings: str = None,
-        **kwargs,
+            self,
+            reader: Reader,
+            schema: str,
+            table: str,
+            pk,
+            partition_by: str = None,
+            engine_settings: str = None,
+            **kwargs,
     ):
         partition_by_str = ""
         engine_settings_str = ""
@@ -60,14 +58,14 @@ class ClickHouseMergeTree(ClickHouse):
         return f"insert into {schema}.{table} {reader.get_source_select_sql(schema, table, )}"
 
     def handle_event(
-        self,
-        tables_dict: Dict,
-        pk,
-        schema: str,
-        table: str,
-        action: str,
-        tmp_event_list: Dict,
-        event: Dict,
+            self,
+            tables_dict: Dict,
+            pk,
+            schema: str,
+            table: str,
+            action: str,
+            tmp_event_list: Dict,
+            event: Dict,
     ):
         values = self.pre_handle_values(tables_dict.get(table).get("skip_decimal"), event["values"])
         event["values"] = values

--- a/synch/writer/merge_tree.py
+++ b/synch/writer/merge_tree.py
@@ -36,14 +36,14 @@ class ClickHouseMergeTree(ClickHouse):
         return sql
 
     def get_table_create_sql(
-            self,
-            reader: Reader,
-            schema: str,
-            table: str,
-            pk,
-            partition_by: str = None,
-            engine_settings: str = None,
-            **kwargs,
+        self,
+        reader: Reader,
+        schema: str,
+        table: str,
+        pk,
+        partition_by: str = None,
+        engine_settings: str = None,
+        **kwargs,
     ):
         partition_by_str = ""
         engine_settings_str = ""
@@ -58,14 +58,14 @@ class ClickHouseMergeTree(ClickHouse):
         return f"insert into {schema}.{table} {reader.get_source_select_sql(schema, table, )}"
 
     def handle_event(
-            self,
-            tables_dict: Dict,
-            pk,
-            schema: str,
-            table: str,
-            action: str,
-            tmp_event_list: Dict,
-            event: Dict,
+        self,
+        tables_dict: Dict,
+        pk,
+        schema: str,
+        table: str,
+        action: str,
+        tmp_event_list: Dict,
+        event: Dict,
     ):
         values = self.pre_handle_values(tables_dict.get(table).get("skip_decimal"), event["values"])
         event["values"] = values


### PR DESCRIPTION
https://github.com/mymarilyn/clickhouse-driver/blob/master/clickhouse_driver/util/escape.py

clickhouse client execute 的时候对参数类型有处理，我觉得这么写更健壮一些，刚好也可以支持主键不同类型的情况🙏