### PR TITLE
mysql syntax compatible 

### DIFF
--- a/synch/convert.py
+++ b/synch/convert.py
@@ -27,7 +27,7 @@ class SqlConvert:
     @classmethod
     def _add_token(cls, schema, parsed, tokens, token_list):
         for i, token in enumerate(tokens):
-            if token.value == "add" and parsed.token_next(i)[1].value != "column":
+            if token.value in ["add", "drop"] and parsed.token_next(i)[1].value != "column":
                 token_list.tokens.append(token)
                 token_list.tokens.append(SQLToken(Whitespace, " "))
                 token_list.tokens.append(SQLToken(Keyword, "column"))
@@ -101,3 +101,19 @@ class SqlConvert:
         parsed = sqlparse.parse(query)[0]
         token_list = cls._add_token(schema, parsed, parsed.tokens, token_list)
         return str(token_list)
+
+    @classmethod
+    def get_table_name(cls, schema: str, query: str):
+        """
+        parse ddl query get table name
+        :param schema:
+        :param query:
+        :return:
+        """
+        table_name = None
+        parsed = sqlparse.parse(query)[0]
+        for i, token in enumerate(parsed.tokens):
+            if isinstance(token, Identifier):
+                if parsed.token_prev(i - 1)[1].value == "table":
+                    table_name = token.value.replace(schema, "").replace("`", "")
+        return table_name

--- a/synch/reader/mysql.py
+++ b/synch/reader/mysql.py
@@ -170,7 +170,7 @@ class Mysql(Reader):
                 if not convent_sql:
                     continue
                 event = {
-                    "table": None,
+                    "table": SqlConvert.get_table_name(schema, query),
                     "schema": schema,
                     "action": "query",
                     "values": {"query": convent_sql},

--- a/synch/writer/merge_tree.py
+++ b/synch/writer/merge_tree.py
@@ -15,6 +15,7 @@ class ClickHouseMergeTree(ClickHouse):
         """
         delete record by pk
         """
+        sql_params = None
         if isinstance(pk, tuple):
             sql = f"alter table {schema}.{table} delete where "
             pks_list = []
@@ -29,23 +30,20 @@ class ClickHouseMergeTree(ClickHouse):
                 pks_list.append("(" + " and ".join(item) + ")")
             sql += " or ".join(pks_list)
         else:
-            if len(pk_list) > 1:
-                pks = ",".join(str(pk) for pk in pk_list)
-            else:
-                pks = pk_list[0]
-            sql = f"alter table {schema}.{table} delete where {pk} in ({pks})"
-        self.execute(sql)
+            sql_params = {pk: tuple(pk_list)}
+            sql = f"alter table {schema}.{table} delete where {pk} in %({pk})s"
+        self.execute(sql, sql_params)
         return sql
 
     def get_table_create_sql(
-        self,
-        reader: Reader,
-        schema: str,
-        table: str,
-        pk,
-        partition_by: str = None,
-        engine_settings: str = None,
-        **kwargs,
+            self,
+            reader: Reader,
+            schema: str,
+            table: str,
+            pk,
+            partition_by: str = None,
+            engine_settings: str = None,
+            **kwargs,
     ):
         partition_by_str = ""
         engine_settings_str = ""
@@ -60,14 +58,14 @@ class ClickHouseMergeTree(ClickHouse):
         return f"insert into {schema}.{table} {reader.get_source_select_sql(schema, table, )}"
 
     def handle_event(
-        self,
-        tables_dict: Dict,
-        pk,
-        schema: str,
-        table: str,
-        action: str,
-        tmp_event_list: Dict,
-        event: Dict,
+            self,
+            tables_dict: Dict,
+            pk,
+            schema: str,
+            table: str,
+            action: str,
+            tmp_event_list: Dict,
+            event: Dict,
     ):
         values = self.pre_handle_values(tables_dict.get(table).get("skip_decimal"), event["values"])
         event["values"] = values

--- a/synch/writer/merge_tree.py
+++ b/synch/writer/merge_tree.py
@@ -36,14 +36,14 @@ class ClickHouseMergeTree(ClickHouse):
         return sql
 
     def get_table_create_sql(
-            self,
-            reader: Reader,
-            schema: str,
-            table: str,
-            pk,
-            partition_by: str = None,
-            engine_settings: str = None,
-            **kwargs,
+        self,
+        reader: Reader,
+        schema: str,
+        table: str,
+        pk,
+        partition_by: str = None,
+        engine_settings: str = None,
+        **kwargs,
     ):
         partition_by_str = ""
         engine_settings_str = ""
@@ -58,14 +58,14 @@ class ClickHouseMergeTree(ClickHouse):
         return f"insert into {schema}.{table} {reader.get_source_select_sql(schema, table, )}"
 
     def handle_event(
-            self,
-            tables_dict: Dict,
-            pk,
-            schema: str,
-            table: str,
-            action: str,
-            tmp_event_list: Dict,
-            event: Dict,
+        self,
+        tables_dict: Dict,
+        pk,
+        schema: str,
+        table: str,
+        action: str,
+        tmp_event_list: Dict,
+        event: Dict,
     ):
         values = self.pre_handle_values(tables_dict.get(table).get("skip_decimal"), event["values"])
         event["values"] = values

--- a/tests/test_sql_convent.py
+++ b/tests/test_sql_convent.py
@@ -38,6 +38,10 @@ class TestSqlConvent(TestCase):
         ret = SqlConvert.to_clickhouse("test", sql)
         self.assertEqual(ret, "alter table test.test drop column name")
 
+        sql = "alter table test drop name"
+        ret = SqlConvert.to_clickhouse("test", sql)
+        self.assertEqual(ret, "alter table test.test drop column name")
+
     def test_change_column(self):
         sql = "alter table test change `column` column2 int null"
         ret = SqlConvert.to_clickhouse("test", sql)


### PR DESCRIPTION
```
ALTER TABLE `test` drop `name`;
ALTER TABLE `test` drop column `name`
```

syntax compatible 

跳过没有在配置里的table的queryEvent