### PR TITLE
[FIX] 修复alter不在配置文件中的表会发送给broker的错误

### DIFF
--- a/synch/reader/mysql.py
+++ b/synch/reader/mysql.py
@@ -108,6 +108,7 @@ class Mysql(Reader):
                 tables.append(table_name)
         only_schemas = self.databases
         only_tables = list(set(tables))
+        logger.info(f'only_schemas:{only_schemas},only_tables:{only_tables}')
         for schema, table, event, file, pos in self._binlog_reading(
                 only_tables=only_tables,
                 only_schemas=only_schemas,
@@ -120,7 +121,7 @@ class Mysql(Reader):
         ):
             if table and table not in schema_tables.get(schema):
                 continue
-            if table and table not in only_tables:
+            if event['table'] and event['table'] not in only_tables:
                 continue
             event["values"] = self.deep_decode_dict(event["values"])
             broker.send(msg=event, schema=schema)

--- a/synch/reader/mysql.py
+++ b/synch/reader/mysql.py
@@ -108,20 +108,20 @@ class Mysql(Reader):
                 tables.append(table_name)
         only_schemas = self.databases
         only_tables = list(set(tables))
-        logger.info(f'only_schemas:{only_schemas},only_tables:{only_tables}')
+        logger.info(f"only_schemas:{only_schemas},only_tables:{only_tables}")
         for schema, table, event, file, pos in self._binlog_reading(
-                only_tables=only_tables,
-                only_schemas=only_schemas,
-                log_file=log_file,
-                log_pos=log_pos,
-                server_id=self.server_id,
-                skip_dmls=self.skip_dmls,
-                skip_delete_tables=self.skip_delete_tables,
-                skip_update_tables=self.skip_update_tables,
+            only_tables=only_tables,
+            only_schemas=only_schemas,
+            log_file=log_file,
+            log_pos=log_pos,
+            server_id=self.server_id,
+            skip_dmls=self.skip_dmls,
+            skip_delete_tables=self.skip_delete_tables,
+            skip_update_tables=self.skip_update_tables,
         ):
             if table and table not in schema_tables.get(schema):
                 continue
-            if event['table'] and event['table'] not in only_tables:
+            if event["table"] and event["table"] not in only_tables:
                 continue
             event["values"] = self.deep_decode_dict(event["values"])
             broker.send(msg=event, schema=schema)
@@ -131,15 +131,15 @@ class Mysql(Reader):
             self.after_send(schema, table)
 
     def _binlog_reading(
-            self,
-            only_tables,
-            only_schemas,
-            log_file,
-            log_pos,
-            server_id,
-            skip_dmls,
-            skip_delete_tables,
-            skip_update_tables,
+        self,
+        only_tables,
+        only_schemas,
+        log_file,
+        log_pos,
+        server_id,
+        skip_dmls,
+        skip_delete_tables,
+        skip_update_tables,
     ) -> Generator:
         stream = BinLogStreamReader(
             connection_settings=dict(

--- a/synch/reader/mysql.py
+++ b/synch/reader/mysql.py
@@ -109,16 +109,18 @@ class Mysql(Reader):
         only_schemas = self.databases
         only_tables = list(set(tables))
         for schema, table, event, file, pos in self._binlog_reading(
-            only_tables=only_tables,
-            only_schemas=only_schemas,
-            log_file=log_file,
-            log_pos=log_pos,
-            server_id=self.server_id,
-            skip_dmls=self.skip_dmls,
-            skip_delete_tables=self.skip_delete_tables,
-            skip_update_tables=self.skip_update_tables,
+                only_tables=only_tables,
+                only_schemas=only_schemas,
+                log_file=log_file,
+                log_pos=log_pos,
+                server_id=self.server_id,
+                skip_dmls=self.skip_dmls,
+                skip_delete_tables=self.skip_delete_tables,
+                skip_update_tables=self.skip_update_tables,
         ):
             if table and table not in schema_tables.get(schema):
+                continue
+            if table and table not in only_tables:
                 continue
             event["values"] = self.deep_decode_dict(event["values"])
             broker.send(msg=event, schema=schema)
@@ -128,15 +130,15 @@ class Mysql(Reader):
             self.after_send(schema, table)
 
     def _binlog_reading(
-        self,
-        only_tables,
-        only_schemas,
-        log_file,
-        log_pos,
-        server_id,
-        skip_dmls,
-        skip_delete_tables,
-        skip_update_tables,
+            self,
+            only_tables,
+            only_schemas,
+            log_file,
+            log_pos,
+            server_id,
+            skip_dmls,
+            skip_delete_tables,
+            skip_update_tables,
     ) -> Generator:
         stream = BinLogStreamReader(
             connection_settings=dict(

--- a/synch/replication/etl.py
+++ b/synch/replication/etl.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("synch.replication.etl")
 
 
 def etl_full(
-        alias: str, schema: str, tables_pk: Dict, renew=False,
+    alias: str, schema: str, tables_pk: Dict, renew=False,
 ):
     """
     full etl

--- a/synch/replication/etl.py
+++ b/synch/replication/etl.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("synch.replication.etl")
 
 
 def etl_full(
-    alias: str, schema: str, tables_pk: Dict, renew=False,
+        alias: str, schema: str, tables_pk: Dict, renew=False,
 ):
     """
     full etl
@@ -59,7 +59,7 @@ def etl_full(
                 for w in get_writer(choice=False):
                     w.execute(
                         w.get_distributed_table_create_sql(
-                            schema, table_name, Settings.get("clickhouse.distributed_suffix")
+                            schema, table_name, Settings.get("clickhouse", "distributed_suffix")
                         )
                     )
             if reader.fix_column_type and not table.get("skip_decimal"):


### PR DESCRIPTION
由于only_tables参数无法作用于alter语句，所以需要在发送broker时进行过滤